### PR TITLE
Fix: Replace redirect_uri with response_uri for direct_post Response Mode

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
@@ -204,7 +204,7 @@ This is an example of a Wallet Instance Attestation:
    * MUST support protocol extensions for SD-JWT VC credential format profile as defined in this specification (#vc_sd_jwt_profile).
    * As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported. Implementations MAY support other ways to invoke the wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
    * Response type MUST be `vp_token`.
-   * Response mode MUST be `direct_post` where the verifier returns `redirect_uri` in response to the HTTP POST request from the wallet, where the wallet redirects the user to, as defined in Section 6.2 of [@!OIDF.OID4VP]. Implementation details for the response mode `direct_post` are given in Section 11.5 of [@!OIDF.OID4VP].
+   * Response mode MUST be `direct_post`. The verifier MUST return `redirect_uri` in response to the HTTP POST request from the wallet, where the wallet redirects the user to, as defined in Section 6.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post` are given in Section 11.5 of [@!OIDF.OID4VP].
    * Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
    * `client_id_scheme` parameter MUST be present in the Authorization Request.
    * `client_id_scheme` value MUST be either `x509_san_dns` or `verifier_attestation`. The Wallet MUST support both. The Verifier MUST support at least one.

--- a/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
@@ -204,7 +204,7 @@ This is an example of a Wallet Instance Attestation:
    * MUST support protocol extensions for SD-JWT VC credential format profile as defined in this specification (#vc_sd_jwt_profile).
    * As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported. Implementations MAY support other ways to invoke the wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
    * Response type MUST be `vp_token`.
-   * Response mode MUST be `direct_post`. The verifier MUST return `redirect_uri` in response to the HTTP POST request from the wallet, where the wallet redirects the user to, as defined in Section 6.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post` are given in Section 11.5 of [@!OIDF.OID4VP].
+   * Response mode MUST be `direct_post`. The Verifier MUST return `redirect_uri` in response to the HTTP POST request from the Wallet, where the Wallet redirects the User to, as defined in Section 6.2 of [@!OIDF.OID4VP]. Implementation considerations for the response mode `direct_post` are given in Section 11.5 of [@!OIDF.OID4VP].
    * Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
    * `client_id_scheme` parameter MUST be present in the Authorization Request.
    * `client_id_scheme` value MUST be either `x509_san_dns` or `verifier_attestation`. The Wallet MUST support both. The Verifier MUST support at least one.

--- a/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
@@ -204,7 +204,7 @@ This is an example of a Wallet Instance Attestation:
    * MUST support protocol extensions for SD-JWT VC credential format profile as defined in this specification (#vc_sd_jwt_profile).
    * As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported. Implementations MAY support other ways to invoke the wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
    * Response type MUST be `vp_token`.
-   * Response mode MUST be `direct_post` with `redirect_uri` as defined in Section 6.2 of [@!OIDF.OID4VP].
+   * Response mode MUST be `direct_post` with `response_uri` as defined in Section 6.2 of [@!OIDF.OID4VP].
    * Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
    * `client_id_scheme` parameter MUST be present in the Authorization Request.
    * `client_id_scheme` value MUST be either `x509_san_dns` or `verifier_attestation`. The Wallet MUST support both. The Verifier MUST support at least one.

--- a/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
@@ -204,7 +204,7 @@ This is an example of a Wallet Instance Attestation:
    * MUST support protocol extensions for SD-JWT VC credential format profile as defined in this specification (#vc_sd_jwt_profile).
    * As a way to invoke the Wallet, at least a custom URL scheme `haip://` MUST be supported. Implementations MAY support other ways to invoke the wallets as agreed by trust frameworks/ecosystems/jurisdictions, not limited to using other custom URL schemes.
    * Response type MUST be `vp_token`.
-   * Response mode MUST be `direct_post` with `response_uri` as defined in Section 6.2 of [@!OIDF.OID4VP].
+   * Response mode MUST be `direct_post` where the verifier returns `redirect_uri` in response to the HTTP POST request from the wallet, where the wallet redirects the user to, as defined in Section 6.2 of [@!OIDF.OID4VP]. Implementation details for the response mode `direct_post` are given in Section 11.5 of [@!OIDF.OID4VP].
    * Authorization Request MUST be sent using the `request_uri` parameter as defined in JWT-Secured Authorization Request (JAR) [@!RFC9101].
    * `client_id_scheme` parameter MUST be present in the Authorization Request.
    * `client_id_scheme` value MUST be either `x509_san_dns` or `verifier_attestation`. The Wallet MUST support both. The Verifier MUST support at least one.


### PR DESCRIPTION
Closes #71.

## 📑 Description
The HAIP currently defines that the response mode has to be `direct_post` with `redirect_uri`. However, using `redirect_uri` isn't allowed in the OpenID4VP spec for `direct_post`. Therefore, this PR proposes to change the Authorization Request parameter to `response_uri`.