### PR TITLE
remove deferred authorization because it has been deprecated in openid4vci

### DIFF
--- a/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
+++ b/openid4vc-high-assurance-interoperability-profile-sd-jwt-vc-1_0.md
@@ -129,7 +129,6 @@ Both sending Credential Offer same-device and cross-device is supported.
 
    * The Wallets MUST perform client authentication as defined in [@!I-D.ietf-oauth-attestation-based-client-auth].
    * Refresh tokens MUST be supported for credential refresh.
-   * Wallets MUST support deferred authorization by being able to process the Token error response parameters `authorization_pending` and `slow_down`, and the credential offer parameter `interval`.
    * The Wallet Attestation JWT scheme is defined in (#wallet-attestation-schema).
 
 Note: It is RECOMMENDED to use ephemeral client attestation JWTs for client authentication in order to prevent linkability across Credential Issuers.


### PR DESCRIPTION
would like to merge asap because LSP needs it.